### PR TITLE
Fix issues with latest vernemq docker images

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export VERNEMQ_IMAGE=${VERNEMQ_IMAGE:="erlio/docker-vernemq"}
+export VERNEMQ_IMAGE=${VERNEMQ_IMAGE:="vernemq/vernemq"}
 export VERNEMQ_IMAGE_VERSION=${VERNEMQ_IMAGE_VERSION:="latest"}
 export VERNEMQ_ROOT=${VERNEMQ_ROOT:="/var/lib/dokku/services/vernemq"}
 

--- a/functions
+++ b/functions
@@ -91,6 +91,9 @@ service_create_container() {
   docker cp $SERVICE_TEMPLATE_NAME:/etc/vernemq/. $SERVICE_ROOT/config &> /dev/null
   docker rm --force "$SERVICE_TEMPLATE_NAME" &> /dev/null
 
+  # setting correct UID and GUID for the mounted directories
+  docker run --rm -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/config" busybox chown 10000:10000 -R /config /data
+
   ID=$(docker run --name "$SERVICE_NAME" -d --restart always -v "$SERVICE_ROOT/data:/var/lib/vernemq" -v "$SERVICE_ROOT/config:/etc/vernemq" --env-file="$SERVICE_ROOT/ENV" --label dokku=service --label dokku.service=vernemq "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
   echo "$ID" > "$SERVICE_ROOT/ID"
 

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -50,7 +50,7 @@ service-destroy-cmd() {
   fi
 
   dokku_log_verbose_quiet "Removing data"
-  docker run --rm -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/config" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" chmod 777 -R /config /data
+  docker run --rm -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/config" busybox chmod 777 -R /config /data
   rm -rf "$SERVICE_ROOT"
 
   dokku_log_info2 "$PLUGIN_SERVICE container deleted: $SERVICE"


### PR DESCRIPTION
Made the following changes since the plugin was not working anymore:
- use official vernemq image
- use correct uid and guid since vernemq is not running as root anymore
- prepare dir for deletion during destroy using busybox (since container runs as root)